### PR TITLE
Add chat completions handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ npm test
 
 ## Architecture
 
-- **`gateway.ts`**: Main Hono app with routing and middleware
+- **`index.ts`**: Main Hono app with routing and middleware
 - **`config.ts`**: YAML configuration loader with Zod validation
 - **`providers/openai.ts`**: OpenAI API client (pass-through)
 - **`providers/anthropic.ts`**: Anthropic API client with format conversion

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
     "version": "1.0.0",
     "description": "Unified AI Gateway for OpenAI and Anthropic APIs",
     "type": "module",
-    "main": "dist/gateway.js",
+    "main": "dist/index.js",
     "scripts": {
-        "dev": "tsx watch src/gateway.ts",
+        "dev": "tsx watch src/index.ts",
         "build": "tsc",
-        "start": "node dist/gateway.js",
+        "start": "node dist/index.js",
         "test": "vitest",
         "lint": "eslint src --ext .ts",
         "format": "prettier --write src"

--- a/src/handlers/chat-completions.ts
+++ b/src/handlers/chat-completions.ts
@@ -1,0 +1,193 @@
+/**
+ * Chat completions request handler.
+ * Mount this router on `/v1/chat/completions`.
+ */
+import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { memoryCache } from "../middleware/cache/index.js";
+import { getConfig, getProviderForModel } from "../config.js";
+import { OpenAIProvider } from "../providers/openai.js";
+import { AnthropicProvider } from "../providers/anthropic.js";
+import type { OpenAIRequest } from "../providers/openai.js";
+
+interface RateLimitEntry {
+  tokens: number;
+  lastRefill: number;
+}
+
+const rateLimitStore = new Map<string, RateLimitEntry>();
+
+class RateLimiter {
+  private refillRate: number;
+  constructor(private maxTokens: number) {
+    this.refillRate = maxTokens;
+  }
+
+  isAllowed(key: string): boolean {
+    const now = Date.now();
+    let entry = rateLimitStore.get(key);
+
+    if (!entry) {
+      entry = { tokens: this.maxTokens - 1, lastRefill: now };
+      rateLimitStore.set(key, entry);
+      return true;
+    }
+
+    const timePassed = now - entry.lastRefill;
+    const tokensToAdd = Math.floor(
+      (timePassed / (60 * 1000)) * this.refillRate,
+    );
+
+    if (tokensToAdd > 0) {
+      entry.tokens = Math.min(this.maxTokens, entry.tokens + tokensToAdd);
+      entry.lastRefill = now;
+    }
+
+    if (entry.tokens > 0) {
+      entry.tokens--;
+      return true;
+    }
+
+    return false;
+  }
+}
+
+function createErrorResponse(
+  c: any,
+  message: string,
+  type = "gateway_error",
+  code = "UNKNOWN",
+  status = 500,
+) {
+  return c.json(
+    {
+      error: {
+        message,
+        type,
+        code,
+      },
+    },
+    status,
+  );
+}
+
+export function chatCompletionsHandler(): Hono {
+  const config = getConfig();
+  const rateLimiter = new RateLimiter(config.rate_limits.per_minute);
+  const openaiProvider = new OpenAIProvider();
+  const anthropicProvider = new AnthropicProvider();
+
+  const router = new Hono();
+
+  // rate limiting middleware
+  router.use(async (c, next) => {
+    const authHeader = c.req.header("authorization");
+    const key = authHeader?.startsWith("Bearer ")
+      ? authHeader.slice(7)
+      : c.req.header("x-forwarded-for") ||
+        c.req.header("x-real-ip") ||
+        "unknown";
+
+    if (!rateLimiter.isAllowed(key)) {
+      return createErrorResponse(
+        c,
+        "Rate limit exceeded",
+        "rate_limit_error",
+        "RATE_LIMIT_EXCEEDED",
+        429,
+      );
+    }
+
+    await next();
+  });
+
+  router.use(memoryCache());
+
+  router.post("/", async (c) => {
+    try {
+      const request: OpenAIRequest = await c.req.json();
+
+      if (!request.model) {
+        return createErrorResponse(
+          c,
+          "Model is required",
+          "invalid_request_error",
+          "MISSING_MODEL",
+          400,
+        );
+      }
+
+      if (!request.messages || !Array.isArray(request.messages)) {
+        return createErrorResponse(
+          c,
+          "Messages array is required",
+          "invalid_request_error",
+          "MISSING_MESSAGES",
+          400,
+        );
+      }
+
+      const provider = getProviderForModel(request.model);
+
+      if (config.logging.level === "debug") {
+        console.log(`Routing model ${request.model} to provider: ${provider}`);
+      }
+
+      let response: Response;
+
+      if (provider === "openai") {
+        response = await openaiProvider.chatCompletions(request);
+      } else {
+        response = await anthropicProvider.chatCompletions(request);
+      }
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        console.error(`Provider error (${response.status}):`, errorBody);
+
+        return createErrorResponse(
+          c,
+          `Provider returned error: ${response.status}`,
+          "provider_error",
+          "PROVIDER_ERROR",
+          response.status,
+        );
+      }
+
+      const responseData = await response.json();
+      return c.json(responseData, response.status as ContentfulStatusCode);
+    } catch (error) {
+      console.error("Gateway error:", error);
+
+      if (error instanceof Error) {
+        if (error.message.includes("timeout")) {
+          return createErrorResponse(
+            c,
+            "Request timeout",
+            "gateway_error",
+            "TIMEOUT",
+            504,
+          );
+        }
+
+        return createErrorResponse(
+          c,
+          error.message,
+          "gateway_error",
+          "INTERNAL_ERROR",
+          500,
+        );
+      }
+
+      return createErrorResponse(
+        c,
+        "Unknown error occurred",
+        "gateway_error",
+        "UNKNOWN_ERROR",
+        500,
+      );
+    }
+  });
+
+  return router;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,220 +1,42 @@
 /**
  * AI Gateway - Main entry point
- * Unified gateway that routes requests to OpenAI or Anthropic based on model mappings
+ * Sets up the Hono application and mounts handlers.
  */
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { logger } from "hono/logger";
+import { loadConfig, getConfig } from "./config.js";
+import { chatCompletionsHandler } from "./handlers/chat-completions.js";
 
-import { Hono } from 'hono';
-import { cors } from 'hono/cors';
-import { logger } from 'hono/logger';
-import type { ContentfulStatusCode } from 'hono/utils/http-status';
-import { loadConfig, getConfig, getProviderForModel } from './config.js';
-import { OpenAIProvider } from './providers/openai.js';
-import { AnthropicProvider } from './providers/anthropic.js';
-import type { OpenAIRequest } from './providers/openai.js';
-import { memoryCache } from './middleware/cache/index.js';
-
-// Rate limiting store (in-memory for simplicity)
-interface RateLimitEntry {
-  tokens: number;
-  lastRefill: number;
-}
-
-const rateLimitStore = new Map<string, RateLimitEntry>();
-
-class RateLimiter {
-  private maxTokens: number;
-  private refillRate: number; // tokens per minute
-
-  constructor(maxTokens: number) {
-    this.maxTokens = maxTokens;
-    this.refillRate = maxTokens;
-  }
-
-  isAllowed(key: string): boolean {
-    const now = Date.now();
-    let entry = rateLimitStore.get(key);
-
-    if (!entry) {
-      entry = { tokens: this.maxTokens - 1, lastRefill: now };
-      rateLimitStore.set(key, entry);
-      return true;
-    }
-
-    // Refill tokens based on time passed
-    const timePassed = now - entry.lastRefill;
-    const tokensToAdd = Math.floor((timePassed / (60 * 1000)) * this.refillRate);
-    
-    if (tokensToAdd > 0) {
-      entry.tokens = Math.min(this.maxTokens, entry.tokens + tokensToAdd);
-      entry.lastRefill = now;
-    }
-
-    if (entry.tokens > 0) {
-      entry.tokens--;
-      return true;
-    }
-
-    return false;
-  }
-}
-
-// Initialize configuration and providers
+// Load configuration before creating handlers
 loadConfig();
 const config = getConfig();
-const rateLimiter = new RateLimiter(config.rate_limits.per_minute);
-const openaiProvider = new OpenAIProvider();
-const anthropicProvider = new AnthropicProvider();
 
 const app = new Hono();
 
-// Configure CORS with explicit options
+// CORS options matching the previous implementation
 const corsOptions = {
-  origin: '*',
-  allowMethods: ['GET', 'POST', 'OPTIONS'],
-  allowHeaders: ['Content-Type', 'Authorization'],
-  exposeHeaders: ['Content-Length'],
+  origin: "*",
+  allowMethods: ["GET", "POST", "OPTIONS"],
+  allowHeaders: ["Content-Type", "Authorization"],
+  exposeHeaders: ["Content-Length"],
   maxAge: 600,
   credentials: true,
 };
 
-// Middleware
-app.use('*', cors(corsOptions));
-app.use('*', logger());
+app.use("*", cors(corsOptions));
+app.use("*", logger());
 
-// Error response helper
-function createErrorResponse(c: any, message: string, type = 'gateway_error', code = 'UNKNOWN', status = 500) {
-  return c.json(
-    {
-      error: {
-        message,
-        type,
-        code,
-      },
-    },
-    status
-  );
-}
-
-// Rate limiting middleware
-app.use('/v1/chat/completions', async (c, next) => {
-  const authHeader = c.req.header('authorization');
-  const key = authHeader?.startsWith('Bearer ')
-    ? authHeader.slice(7)
-    : c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown';
-
-  if (!rateLimiter.isAllowed(key)) {
-    return createErrorResponse(
-      c,
-      'Rate limit exceeded',
-      'rate_limit_error',
-      'RATE_LIMIT_EXCEEDED',
-      429
-    );
-  }
-
-  await next();
-});
-
-// Cache middleware to store non-streaming responses in memory
-app.use('/v1/chat/completions', memoryCache());
-
-// Main chat completions endpoint
-app.post('/v1/chat/completions', async (c) => {
-  try {
-    const request: OpenAIRequest = await c.req.json();
-    
-    if (!request.model) {
-      return createErrorResponse(
-        c,
-        'Model is required',
-        'invalid_request_error',
-        'MISSING_MODEL',
-        400
-      );
-    }
-
-    if (!request.messages || !Array.isArray(request.messages)) {
-      return createErrorResponse(
-        c,
-        'Messages array is required',
-        'invalid_request_error',
-        'MISSING_MESSAGES',
-        400
-      );
-    }
-
-    const provider = getProviderForModel(request.model);
-    
-    if (config.logging.level === 'debug') {
-      console.log(`Routing model ${request.model} to provider: ${provider}`);
-    }
-
-    let response: Response;
-    
-    if (provider === 'openai') {
-      response = await openaiProvider.chatCompletions(request);
-    } else {
-      response = await anthropicProvider.chatCompletions(request);
-    }
-
-    // Handle provider errors
-    if (!response.ok) {
-      const errorBody = await response.text();
-      console.error(`Provider error (${response.status}):`, errorBody);
-      
-      return createErrorResponse(
-        c,
-        `Provider returned error: ${response.status}`,
-        'provider_error',
-        'PROVIDER_ERROR',
-        response.status
-      );
-    }
-
-    // Convert the provider's response to a format Hono can handle
-    const responseData = await response.json();
-    return c.json(responseData, response.status as ContentfulStatusCode);
-
-  } catch (error) {
-    console.error('Gateway error:', error);
-    
-    if (error instanceof Error) {
-      if (error.message.includes('timeout')) {
-        return createErrorResponse(
-          c,
-          'Request timeout',
-          'gateway_error',
-          'TIMEOUT',
-          504
-        );
-      }
-      
-      return createErrorResponse(
-        c,
-        error.message,
-        'gateway_error',
-        'INTERNAL_ERROR',
-        500
-      );
-    }
-
-    return createErrorResponse(
-      c,
-      'Unknown error occurred',
-      'gateway_error',
-      'UNKNOWN_ERROR',
-      500
-    );
-  }
-});
+// Mount chat completions router
+app.route("/v1/chat/completions", chatCompletionsHandler());
 
 // Health check endpoint
-app.get('/health', (c) => {
-  return c.json({ status: 'healthy', timestamp: new Date().toISOString() });
+app.get("/health", (c) => {
+  return c.json({ status: "healthy", timestamp: new Date().toISOString() });
 });
 
 // Index page - proof the server is running
-app.get('/', (c) => {
+app.get("/", (c) => {
   const html = `
 <!DOCTYPE html>
 <html lang="en">
@@ -228,7 +50,7 @@ app.get('/', (c) => {
             padding: 0;
             box-sizing: border-box;
         }
-        
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -238,7 +60,7 @@ app.get('/', (c) => {
             justify-content: center;
             color: #333;
         }
-        
+
         .container {
             background: rgba(255, 255, 255, 0.95);
             backdrop-filter: blur(10px);
@@ -250,7 +72,7 @@ app.get('/', (c) => {
             text-align: center;
             border: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .logo {
             width: 80px;
             height: 80px;
@@ -264,7 +86,7 @@ app.get('/', (c) => {
             color: white;
             font-weight: bold;
         }
-        
+
         h1 {
             font-size: 2.5rem;
             font-weight: 700;
@@ -274,14 +96,14 @@ app.get('/', (c) => {
             -webkit-text-fill-color: transparent;
             background-clip: text;
         }
-        
+
         .subtitle {
             font-size: 1.1rem;
             color: #666;
             margin-bottom: 2rem;
             font-weight: 400;
         }
-        
+
         .status {
             display: inline-flex;
             align-items: center;
@@ -294,7 +116,7 @@ app.get('/', (c) => {
             margin-bottom: 2rem;
             font-size: 0.9rem;
         }
-        
+
         .status::before {
             content: '';
             width: 8px;
@@ -303,26 +125,26 @@ app.get('/', (c) => {
             border-radius: 50%;
             animation: pulse 2s infinite;
         }
-        
+
         @keyframes pulse {
             0%, 100% { opacity: 1; }
             50% { opacity: 0.5; }
         }
-        
+
         .info-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
             gap: 1.5rem;
             margin-bottom: 2rem;
         }
-        
+
         .info-card {
             background: rgba(102, 126, 234, 0.1);
             border-radius: 12px;
             padding: 1.5rem;
             border: 1px solid rgba(102, 126, 234, 0.2);
         }
-        
+
         .info-card h3 {
             font-size: 0.9rem;
             text-transform: uppercase;
@@ -331,13 +153,13 @@ app.get('/', (c) => {
             margin-bottom: 0.5rem;
             font-weight: 600;
         }
-        
+
         .info-card p {
             font-size: 1.1rem;
             font-weight: 600;
             color: #333;
         }
-        
+
         .endpoint {
             background: #f8fafc;
             border: 1px solid #e2e8f0;
@@ -349,14 +171,14 @@ app.get('/', (c) => {
             margin-bottom: 1.5rem;
             word-break: break-all;
         }
-        
+
         .providers {
             display: flex;
             justify-content: center;
             gap: 1rem;
             margin-top: 1rem;
         }
-        
+
         .provider {
             background: white;
             border: 2px solid #e2e8f0;
@@ -366,7 +188,7 @@ app.get('/', (c) => {
             font-weight: 600;
             color: #4a5568;
         }
-        
+
         .footer {
             margin-top: 2rem;
             padding-top: 1.5rem;
@@ -374,21 +196,21 @@ app.get('/', (c) => {
             font-size: 0.85rem;
             color: #666;
         }
-        
+
         @media (max-width: 640px) {
             .container {
                 padding: 2rem;
                 margin: 1rem;
             }
-            
+
             h1 {
                 font-size: 2rem;
             }
-            
+
             .info-grid {
                 grid-template-columns: 1fr;
             }
-            
+
             .providers {
                 flex-direction: column;
                 align-items: center;
@@ -401,11 +223,11 @@ app.get('/', (c) => {
         <div class="logo">AI</div>
         <h1>AI Gateway</h1>
         <p class="subtitle">Unified API for OpenAI and Anthropic</p>
-        
+
         <div class="status">
             Gateway Online
         </div>
-        
+
         <div class="info-grid">
             <div class="info-card">
                 <h3>Endpoint</h3>
@@ -424,16 +246,16 @@ app.get('/', (c) => {
                 <p>${config.default_provider.toUpperCase()}</p>
             </div>
         </div>
-        
+
         <div class="endpoint">
-            POST ${c.req.url.replace(c.req.path, '')}/v1/chat/completions
+            POST ${c.req.url.replace(c.req.path, "")}/v1/chat/completions
         </div>
-        
+
         <div class="providers">
             <div class="provider">OpenAI</div>
             <div class="provider">Anthropic</div>
         </div>
-        
+
         <div class="footer">
             Ready to route your AI requests<br>
             <strong>Status:</strong> Healthy • <strong>Uptime:</strong> ${process.uptime().toFixed(0)}s
@@ -442,7 +264,7 @@ app.get('/', (c) => {
 </body>
 </html>
   `;
-  
+
   return c.html(html);
 });
 
@@ -453,7 +275,7 @@ console.log(`🚀 AI Gateway starting on port ${port}`);
 console.log(`📝 Logging level: ${config.logging.level}`);
 console.log(`⚡ Rate limit: ${config.rate_limits.per_minute} requests/minute`);
 
-import { serve } from '@hono/node-server';
+import { serve } from "@hono/node-server";
 
 const server = serve({
   fetch: app.fetch,
@@ -462,10 +284,9 @@ const server = serve({
 
 console.log(`✅ Server is running on http://localhost:${port}`);
 
-// Handle shutdown gracefully
-process.on('SIGTERM', () => {
-  console.log('SIGTERM signal received: closing HTTP server');
+process.on("SIGTERM", () => {
+  console.log("SIGTERM signal received: closing HTTP server");
   server.close(() => {
-    console.log('HTTP server closed');
+    console.log("HTTP server closed");
   });
 });


### PR DESCRIPTION
## Summary
- move gateway to `index.ts`
- implement `handlers/chat-completions.ts` with provider selection logic
- update package scripts to use `index.ts`
- document new entry file name in README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_6853d36f47ec832cb83269249372bb45