### PR TITLE
Add guardrails middleware with AWS Comprehend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A unified gateway that provides a single OpenAI-compatible endpoint for both Ope
 - **Rate Limiting**: Token-bucket rate limiting per IP/API key
 - **Error Handling**: Consistent OpenAI-style error responses
 - **Configuration**: YAML-based configuration with environment variable secrets
+- **Guardrails**: Optional PII detection using Amazon Comprehend
 
 ## Setup
 
@@ -90,7 +91,8 @@ The `config.yaml` file controls:
 - **API Endpoints**: Configure provider endpoints
 - **Rate Limiting**: Set requests per minute limits
 - **Timeouts**: Configure request timeouts
-- **Logging**: Set log levels
+ - **Logging**: Set log levels
+ - **Guardrails**: Optional PII detection settings
 
 Example configuration:
 ```yaml
@@ -114,6 +116,13 @@ rate_limits:
 
 logging:
   level: info
+
+guardrails:
+  enabled: false
+  mode: log
+  aws_region: us-east-1
+  access_key_id_env: AWS_ACCESS_KEY_ID
+  secret_access_key_env: AWS_SECRET_ACCESS_KEY
 ```
 
 ## Error Handling

--- a/config.yaml
+++ b/config.yaml
@@ -26,3 +26,10 @@ rate_limits:
 
 logging:
   level: info
+
+guardrails:
+  enabled: false
+  mode: log
+  aws_region: us-east-1
+  access_key_id_env: AWS_ACCESS_KEY_ID
+  secret_access_key_env: AWS_SECRET_ACCESS_KEY

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "@hono/node-server": "^1.14.4",
         "hono": "^4.0.0",
         "yaml": "^2.3.4",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "@aws-sdk/client-comprehend": "^3.541.0"
     },
     "devDependencies": {
         "@types/node": "^20.11.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,14 @@ const ProviderConfigSchema = z.object({
   endpoint: z.string().url(),
 });
 
+const GuardrailsConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  mode: z.enum(['log', 'block']).default('log'),
+  aws_region: z.string().default('us-east-1'),
+  access_key_id_env: z.string().default('AWS_ACCESS_KEY_ID'),
+  secret_access_key_env: z.string().default('AWS_SECRET_ACCESS_KEY'),
+});
+
 const ConfigSchema = z.object({
   default_provider: z.enum(['openai', 'anthropic']),
   timeout_ms: z.number().positive().default(30000),
@@ -27,8 +35,10 @@ const ConfigSchema = z.object({
   logging: z.object({
     level: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
   }),
+  guardrails: GuardrailsConfigSchema.default({})
 });
 
+export type GuardrailsConfig = z.infer<typeof GuardrailsConfigSchema>;
 export type Config = z.infer<typeof ConfigSchema>;
 export type ProviderName = 'openai' | 'anthropic';
 
@@ -40,7 +50,7 @@ export function loadConfig(configPath = 'config.yaml'): Config {
     const rawConfig = parse(configFile);
     
     config = ConfigSchema.parse(rawConfig);
-    
+
     // Validate API keys are present in environment
     for (const [providerName, providerConfig] of Object.entries(config.providers)) {
       const apiKey = process.env[providerConfig.api_key_env];
@@ -49,7 +59,16 @@ export function loadConfig(configPath = 'config.yaml'): Config {
         process.exit(1);
       }
     }
-    
+
+    if (config.guardrails.enabled) {
+      const access = process.env[config.guardrails.access_key_id_env];
+      const secret = process.env[config.guardrails.secret_access_key_env];
+      if (!access || !secret) {
+        console.error('Guardrails enabled but AWS credentials are missing');
+        process.exit(1);
+      }
+    }
+
     console.log(`Configuration loaded successfully from ${configPath}`);
     return config;
   } catch (error) {

--- a/src/handlers/chat-completions.ts
+++ b/src/handlers/chat-completions.ts
@@ -5,6 +5,7 @@
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { memoryCache } from "../middleware/cache/index.js";
+import { guardrails } from "../middleware/guardrails/index.js";
 import { getConfig, getProviderForModel } from "../config.js";
 import { OpenAIProvider } from "../providers/openai.js";
 import { AnthropicProvider } from "../providers/anthropic.js";
@@ -102,6 +103,7 @@ export function chatCompletionsHandler(): Hono {
   });
 
   router.use(memoryCache());
+  router.use(guardrails());
 
   router.post("/", async (c) => {
     try {

--- a/src/middleware/guardrails/index.ts
+++ b/src/middleware/guardrails/index.ts
@@ -1,0 +1,72 @@
+import type { MiddlewareHandler } from 'hono';
+import { ComprehendClient, DetectPiiEntitiesCommand } from '@aws-sdk/client-comprehend';
+import { getConfig } from '../../config.js';
+
+interface DetectionResult {
+  entities: string[];
+}
+
+async function detectPii(client: ComprehendClient, text: string): Promise<DetectionResult> {
+  if (!text.trim()) return { entities: [] };
+  try {
+    const res = await client.send(new DetectPiiEntitiesCommand({ Text: text, LanguageCode: 'en' }));
+    const entities = (res.Entities || []).map(e => e.Type).filter(Boolean) as string[];
+    return { entities };
+  } catch (err) {
+    console.error('Guardrails detection error:', err);
+    return { entities: [] };
+  }
+}
+
+export function guardrails(): MiddlewareHandler {
+  const config = getConfig().guardrails;
+  if (!config.enabled) {
+    return async (_, next) => {
+      await next();
+    };
+  }
+
+  const client = new ComprehendClient({
+    region: config.aws_region,
+    credentials: {
+      accessKeyId: process.env[config.access_key_id_env] || '',
+      secretAccessKey: process.env[config.secret_access_key_env] || '',
+    },
+  });
+
+  const mode = config.mode;
+
+  return async (c, next) => {
+    const reqClone = (c.req as any).raw?.clone ? (c.req as any).raw.clone() : (c.req as any).clone();
+    const reqText = await reqClone.text();
+    const reqDetection = await detectPii(client, reqText);
+    if (reqDetection.entities.length) {
+      console.warn(`Guardrails request entities: ${reqDetection.entities.join(', ')}`);
+      if (mode === 'block') {
+        return c.json(
+          { error: { message: 'PII detected in request', type: 'guardrails_violation', code: 'PII_DETECTED' } },
+          400,
+        );
+      }
+    }
+
+    await next();
+
+    const contentType = c.res.headers.get('content-type') || '';
+    if (!contentType.includes('text/event-stream')) {
+      const resClone = c.res.clone();
+      const resText = await resClone.text();
+      const resDetection = await detectPii(client, resText);
+      if (resDetection.entities.length) {
+        console.warn(`Guardrails response entities: ${resDetection.entities.join(', ')}`);
+        if (mode === 'block') {
+          return c.json(
+            { error: { message: 'PII detected in response', type: 'guardrails_violation', code: 'PII_DETECTED' } },
+            502,
+          );
+        }
+      }
+      c.res = resClone;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- introduce Guardrails middleware using Amazon Comprehend for PII detection
- extend config schema and example `config.yaml` with guardrails settings
- wire guardrails middleware into chat completion handler
- document guardrails feature and configuration
- add AWS Comprehend dependency

## Testing
- `npm run build` *(fails: Cannot find module dependencies)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68551d6557c4832cab57524312bf8e78