### PR TITLE
Add data privacy guardrail logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,18 @@ A unified gateway that provides a single OpenAI-compatible endpoint for both Ope
 - **Rate Limiting**: Token-bucket rate limiting per IP/API key
 - **Error Handling**: Consistent OpenAI-style error responses
 - **Configuration**: YAML-based configuration with environment variable secrets
-- **Guardrails**: Optional PII detection using Amazon Comprehend
+- **Guardrails**: Data privacy checks with PII detection logged per request
 
 ## Setup
 
 1. **Install dependencies:**
+
    ```bash
    npm install
    ```
 
 2. **Set environment variables:**
+
    ```bash
    export OPENAI_API_KEY="your-openai-key"
    export ANTHROPIC_API_KEY="your-anthropic-key"
@@ -36,11 +38,13 @@ A unified gateway that provides a single OpenAI-compatible endpoint for both Ope
 ## Running
 
 ### Development
+
 ```bash
 npm run dev
 ```
 
 ### Production
+
 ```bash
 npm run build
 npm start
@@ -51,6 +55,7 @@ The gateway runs on port 3000 by default (configurable via `PORT` environment va
 ## API Usage
 
 ### Non-streaming Request (OpenAI model)
+
 ```bash
 curl -X POST http://localhost:3000/v1/chat/completions \
   -H "Content-Type: application/json" \
@@ -65,6 +70,7 @@ curl -X POST http://localhost:3000/v1/chat/completions \
 ```
 
 ### Streaming Request (Anthropic model)
+
 ```bash
 curl -X POST http://localhost:3000/v1/chat/completions \
   -H "Content-Type: application/json" \
@@ -79,6 +85,7 @@ curl -X POST http://localhost:3000/v1/chat/completions \
 ```
 
 ### Health Check
+
 ```bash
 curl http://localhost:3000/health
 ```
@@ -91,10 +98,11 @@ The `config.yaml` file controls:
 - **API Endpoints**: Configure provider endpoints
 - **Rate Limiting**: Set requests per minute limits
 - **Timeouts**: Configure request timeouts
- - **Logging**: Set log levels
- - **Guardrails**: Optional PII detection settings
+- **Logging**: Set log levels
+- **Guardrails**: Optional PII detection settings
 
 Example configuration:
+
 ```yaml
 default_provider: openai
 timeout_ms: 30000
@@ -118,16 +126,18 @@ logging:
   level: info
 
 guardrails:
-  enabled: false
-  mode: log
-  aws_region: us-east-1
-  access_key_id_env: AWS_ACCESS_KEY_ID
-  secret_access_key_env: AWS_SECRET_ACCESS_KEY
+  data_privacy:
+    enabled: false
+    mode: log
+    aws_region: us-east-1
+    access_key_id_env: AWS_ACCESS_KEY_ID
+    secret_access_key_env: AWS_SECRET_ACCESS_KEY
 ```
 
 ## Error Handling
 
 All errors return OpenAI-compatible error format:
+
 ```json
 {
   "error": {
@@ -141,6 +151,7 @@ All errors return OpenAI-compatible error format:
 ## Testing
 
 Run tests:
+
 ```bash
 npm test
 ```
@@ -157,28 +168,32 @@ npm test
 ## How to Run
 
 1. **Clone and install:**
+
    ```bash
    npm install
    ```
 
 2. **Set your API keys:**
+
    ```bash
    export OPENAI_API_KEY="sk-..."
    export ANTHROPIC_API_KEY="sk-ant-..."
    ```
 
 3. **Start development server:**
+
    ```bash
    npm run dev
    ```
 
 4. **Test with cURL:**
+
    ```bash
    # Test OpenAI model (pass-through)
    curl -X POST http://localhost:3000/v1/chat/completions \
      -H "Content-Type: application/json" \
      -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello!"}]}'
-   
+
    # Test Anthropic model (transcoded)
    curl -X POST http://localhost:3000/v1/chat/completions \
      -H "Content-Type: application/json" \

--- a/config.yaml
+++ b/config.yaml
@@ -28,8 +28,9 @@ logging:
   level: info
 
 guardrails:
-  enabled: false
-  mode: log
-  aws_region: us-east-1
-  access_key_id_env: AWS_ACCESS_KEY_ID
-  secret_access_key_env: AWS_SECRET_ACCESS_KEY
+  data_privacy:
+    enabled: false
+    mode: log
+    aws_region: us-east-1
+    access_key_id_env: AWS_ACCESS_KEY_ID
+    secret_access_key_env: AWS_SECRET_ACCESS_KEY

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,9 +3,9 @@
  * Loads YAML config and validates with Zod schemas
  */
 
-import { readFileSync } from 'fs';
-import { parse } from 'yaml';
-import { z } from 'zod';
+import { readFileSync } from "fs";
+import { parse } from "yaml";
+import { z } from "zod";
 
 // Zod schemas for configuration validation
 const ProviderConfigSchema = z.object({
@@ -13,58 +13,69 @@ const ProviderConfigSchema = z.object({
   endpoint: z.string().url(),
 });
 
-const GuardrailsConfigSchema = z.object({
+const DataPrivacyConfigSchema = z.object({
   enabled: z.boolean().default(false),
-  mode: z.enum(['log', 'block']).default('log'),
-  aws_region: z.string().default('us-east-1'),
-  access_key_id_env: z.string().default('AWS_ACCESS_KEY_ID'),
-  secret_access_key_env: z.string().default('AWS_SECRET_ACCESS_KEY'),
+  mode: z.enum(["log", "block"]).default("log"),
+  aws_region: z.string().default("us-east-1"),
+  access_key_id_env: z.string().default("AWS_ACCESS_KEY_ID"),
+  secret_access_key_env: z.string().default("AWS_SECRET_ACCESS_KEY"),
+});
+
+const GuardrailsConfigSchema = z.object({
+  data_privacy: DataPrivacyConfigSchema.default({}),
 });
 
 const ConfigSchema = z.object({
-  default_provider: z.enum(['openai', 'anthropic']),
+  default_provider: z.enum(["openai", "anthropic"]),
   timeout_ms: z.number().positive().default(30000),
   providers: z.object({
     openai: ProviderConfigSchema,
     anthropic: ProviderConfigSchema,
   }),
-  model_mappings: z.record(z.string(), z.enum(['openai', 'anthropic'])),
+  model_mappings: z.record(z.string(), z.enum(["openai", "anthropic"])),
   rate_limits: z.object({
     per_minute: z.number().positive().default(60),
   }),
   logging: z.object({
-    level: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
+    level: z.enum(["debug", "info", "warn", "error"]).default("info"),
   }),
-  guardrails: GuardrailsConfigSchema.default({})
+  guardrails: GuardrailsConfigSchema.default({}),
 });
 
+export type DataPrivacyConfig = z.infer<typeof DataPrivacyConfigSchema>;
 export type GuardrailsConfig = z.infer<typeof GuardrailsConfigSchema>;
 export type Config = z.infer<typeof ConfigSchema>;
-export type ProviderName = 'openai' | 'anthropic';
+export type ProviderName = "openai" | "anthropic";
 
 let config: Config;
 
-export function loadConfig(configPath = 'config.yaml'): Config {
+export function loadConfig(configPath = "config.yaml"): Config {
   try {
-    const configFile = readFileSync(configPath, 'utf8');
+    const configFile = readFileSync(configPath, "utf8");
     const rawConfig = parse(configFile);
-    
+
     config = ConfigSchema.parse(rawConfig);
 
     // Validate API keys are present in environment
-    for (const [providerName, providerConfig] of Object.entries(config.providers)) {
+    for (const [providerName, providerConfig] of Object.entries(
+      config.providers,
+    )) {
       const apiKey = process.env[providerConfig.api_key_env];
       if (!apiKey) {
-        console.error(`Missing API key: ${providerConfig.api_key_env} for provider ${providerName}`);
+        console.error(
+          `Missing API key: ${providerConfig.api_key_env} for provider ${providerName}`,
+        );
         process.exit(1);
       }
     }
 
-    if (config.guardrails.enabled) {
-      const access = process.env[config.guardrails.access_key_id_env];
-      const secret = process.env[config.guardrails.secret_access_key_env];
+    if (config.guardrails.data_privacy.enabled) {
+      const access =
+        process.env[config.guardrails.data_privacy.access_key_id_env];
+      const secret =
+        process.env[config.guardrails.data_privacy.secret_access_key_env];
       if (!access || !secret) {
-        console.error('Guardrails enabled but AWS credentials are missing');
+        console.error("Guardrails enabled but AWS credentials are missing");
         process.exit(1);
       }
     }
@@ -72,14 +83,14 @@ export function loadConfig(configPath = 'config.yaml'): Config {
     console.log(`Configuration loaded successfully from ${configPath}`);
     return config;
   } catch (error) {
-    console.error('Failed to load configuration:', error);
+    console.error("Failed to load configuration:", error);
     process.exit(1);
   }
 }
 
 export function getConfig(): Config {
   if (!config) {
-    throw new Error('Configuration not loaded. Call loadConfig() first.');
+    throw new Error("Configuration not loaded. Call loadConfig() first.");
   }
   return config;
 }

--- a/src/middleware/guardrails/index.ts
+++ b/src/middleware/guardrails/index.ts
@@ -1,25 +1,41 @@
-import type { MiddlewareHandler } from 'hono';
-import { ComprehendClient, DetectPiiEntitiesCommand } from '@aws-sdk/client-comprehend';
-import { getConfig } from '../../config.js';
+import type { MiddlewareHandler } from "hono";
+import {
+  ComprehendClient,
+  DetectPiiEntitiesCommand,
+} from "@aws-sdk/client-comprehend";
+import { getConfig } from "../../config.js";
 
 interface DetectionResult {
   entities: string[];
 }
 
-async function detectPii(client: ComprehendClient, text: string): Promise<DetectionResult> {
+export interface GuardrailDetectionLog {
+  type: "data_privacy";
+  stage: "request" | "response";
+  labels: string[];
+}
+
+async function detectPii(
+  client: ComprehendClient,
+  text: string,
+): Promise<DetectionResult> {
   if (!text.trim()) return { entities: [] };
   try {
-    const res = await client.send(new DetectPiiEntitiesCommand({ Text: text, LanguageCode: 'en' }));
-    const entities = (res.Entities || []).map(e => e.Type).filter(Boolean) as string[];
+    const res = await client.send(
+      new DetectPiiEntitiesCommand({ Text: text, LanguageCode: "en" }),
+    );
+    const entities = (res.Entities || [])
+      .map((e) => e.Type)
+      .filter(Boolean) as string[];
     return { entities };
   } catch (err) {
-    console.error('Guardrails detection error:', err);
+    console.error("Guardrails detection error:", err);
     return { entities: [] };
   }
 }
 
 export function guardrails(): MiddlewareHandler {
-  const config = getConfig().guardrails;
+  const config = getConfig().guardrails.data_privacy;
   if (!config.enabled) {
     return async (_, next) => {
       await next();
@@ -29,22 +45,41 @@ export function guardrails(): MiddlewareHandler {
   const client = new ComprehendClient({
     region: config.aws_region,
     credentials: {
-      accessKeyId: process.env[config.access_key_id_env] || '',
-      secretAccessKey: process.env[config.secret_access_key_env] || '',
+      accessKeyId: process.env[config.access_key_id_env] || "",
+      secretAccessKey: process.env[config.secret_access_key_env] || "",
     },
   });
 
   const mode = config.mode;
 
   return async (c, next) => {
-    const reqClone = (c.req as any).raw?.clone ? (c.req as any).raw.clone() : (c.req as any).clone();
+    const detections =
+      (c.get("guardrail_detections") as GuardrailDetectionLog[] | undefined) ||
+      [];
+    c.set("guardrail_detections", detections);
+    const reqClone = (c.req as any).raw?.clone
+      ? (c.req as any).raw.clone()
+      : (c.req as any).clone();
     const reqText = await reqClone.text();
     const reqDetection = await detectPii(client, reqText);
     if (reqDetection.entities.length) {
-      console.warn(`Guardrails request entities: ${reqDetection.entities.join(', ')}`);
-      if (mode === 'block') {
+      console.warn(
+        `Guardrails request entities: ${reqDetection.entities.join(", ")}`,
+      );
+      detections.push({
+        type: "data_privacy",
+        stage: "request",
+        labels: reqDetection.entities,
+      });
+      if (mode === "block") {
         return c.json(
-          { error: { message: 'PII detected in request', type: 'guardrails_violation', code: 'PII_DETECTED' } },
+          {
+            error: {
+              message: "PII detected in request",
+              type: "guardrails_violation",
+              code: "PII_DETECTED",
+            },
+          },
           400,
         );
       }
@@ -52,25 +87,30 @@ export function guardrails(): MiddlewareHandler {
 
     await next();
 
-    const contentType = c.res.headers.get('content-type') || '';
-    if (!contentType.includes('text/event-stream')) {
+    const contentType = c.res.headers.get("content-type") || "";
+    if (!contentType.includes("text/event-stream")) {
       const resClone = c.res.clone();
       const resText = await resClone.text();
       const resDetection = await detectPii(client, resText);
       if (resDetection.entities.length) {
         console.warn(
-          `Guardrails response entities: ${resDetection.entities.join(', ')}`,
+          `Guardrails response entities: ${resDetection.entities.join(", ")}`,
         );
-        if (mode === 'block') {
+        detections.push({
+          type: "data_privacy",
+          stage: "response",
+          labels: resDetection.entities,
+        });
+        if (mode === "block") {
           c.res = new Response(
             JSON.stringify({
               error: {
-                message: 'PII detected in response',
-                type: 'guardrails_violation',
-                code: 'PII_DETECTED',
+                message: "PII detected in response",
+                type: "guardrails_violation",
+                code: "PII_DETECTED",
               },
             }),
-            { status: 502, headers: { 'Content-Type': 'application/json' } },
+            { status: 502, headers: { "Content-Type": "application/json" } },
           );
           return;
         }


### PR DESCRIPTION
## Summary
- support nested `guardrails.data_privacy` config
- capture guardrail detections in request logs
- log PII labels for both request and response
- document new configuration and guardrail logging

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855312d3cb4832c82c3b9cc20621d8b